### PR TITLE
fix(FEC-8339): when selecting full screen the video page displayed black

### DIFF
--- a/src/vr.js
+++ b/src/vr.js
@@ -255,7 +255,7 @@ class Vr extends BasePlugin {
   _updateCanvasSize(): void {
     if (this._renderer) {
       const dimensions: Dimensions = this._getCanvasDimensions();
-      this._renderer.setSize(dimensions.width, dimensions.height);
+      this._renderer.setSize(dimensions.width, dimensions.height, false);
     }
   }
 


### PR DESCRIPTION
Caused by the canvas style width/height (float) is different from is inner width/height (integer)  
so, do not update the canvas style but the inner width/height only