### PR TITLE
fix(FEC-8342, FEC-8345): video is not playing 360 after pre-roll

### DIFF
--- a/src/vr.js
+++ b/src/vr.js
@@ -50,7 +50,6 @@ class Vr extends BasePlugin {
     return Env.browser.name !== 'IE' || (Env.browser.major === '11' && (Env.os.version === '8.1' || Env.os.version === '10'));
   }
 
-  _isSupported: boolean;
   _renderer: any;
   _scene: any;
   _camera: any;
@@ -85,16 +84,14 @@ class Vr extends BasePlugin {
     this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, event => {
       if (this.player.isVr()) {
         this.logger.debug('VR entry has detected');
-        this._addMotionBindings();
-        this.eventManager.listen(this.player, this.player.Event.MEDIA_LOADED, () => {
-          if (this._isVrSupported(event.payload.selectedSource[0])) {
-            this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => this._initComponents());
-            this.eventManager.listen(this.player, this.player.Event.ENDED, () => this._cancelAnimationFrame());
-            this.eventManager.listen(this.player, this.player.Event.PLAY, () => this._onPlay());
-            this.eventManager.listen(this.player, this.player.Event.PLAYING, () => this._onPlaying());
-            this.eventManager.listen(window, 'resize', () => this._updateCanvasSize());
-          }
-        });
+        if (this._isVrSupported(event.payload.selectedSource[0])) {
+          this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => this._initComponents());
+          this.eventManager.listen(this.player, this.player.Event.ENDED, () => this._cancelAnimationFrame());
+          this.eventManager.listen(this.player, this.player.Event.PLAY, () => this._onPlay());
+          this.eventManager.listen(this.player, this.player.Event.PLAYING, () => this._onPlaying());
+          this.eventManager.listen(window, 'resize', () => this._updateCanvasSize());
+          this._addMotionBindings();
+        }
       }
     });
   }
@@ -123,9 +120,9 @@ class Vr extends BasePlugin {
       this.player.dispatchEvent(
         new FakeEvent(this.player.Event.ERROR, new PKError(PKError.Severity.CRITICAL, PKError.Category.VR, PKError.Code.VR_NOT_SUPPORTED, message))
       );
-      this._isSupported = false;
+      return false;
     }
-    return this._isSupported;
+    return true;
   }
 
   /**
@@ -325,7 +322,6 @@ class Vr extends BasePlugin {
   }
 
   _initMembers(): void {
-    this._isSupported = true;
     this._renderer = null;
     this._scene = null;
     this._camera = null;
@@ -346,11 +342,9 @@ class Vr extends BasePlugin {
   }
 
   _onOverlayActionPointerDown(event: any): void {
-    if (this._isSupported) {
-      this._pointerDown = true;
-      this._previousX = event.clientX || event.touches[0].clientX;
-      this._previousY = event.clientY || event.touches[0].clientY;
-    }
+    this._pointerDown = true;
+    this._previousX = event.clientX || event.touches[0].clientX;
+    this._previousY = event.clientY || event.touches[0].clientY;
   }
 
   _onDocumentPointerMove(event: any): void {


### PR DESCRIPTION
the ads preset drops the `overlay-action` div and it could be non exist on `medialoaded` (also on `firstplay` and even `playbackstarted`).
So attach to `overlay-action` div on `sourceloaded`.