### PR TITLE
fix(FEC-8357,FEC-8348): VR is not working on Safari and Samsung Native Browser

### DIFF
--- a/src/vr.js
+++ b/src/vr.js
@@ -314,8 +314,8 @@ class Vr extends BasePlugin {
   }
 
   /**
-   * In some browsers (android browser for example) the videoWidth is unknown but after soem time after playing
-   * For this case wh have to retry gathering this value by an interval, and limit it until a failure.
+   * In some browsers (android browser for example) the videoWidth is unknown but in some time after playing.
+   * For this case we have to retry gathering this value by an interval, and limit it until a failure.
    * @private
    */
   _updateCanvasSizeByInterval(): void {


### PR DESCRIPTION
* getting the canvas dimensions by interval because the video width is unset until sometime after playing
* set `crossorigin: anonymous` for safari/iOS/android browser