### PR TITLE
fix(FEC-8458): black screen on win 10 IE11

### DIFF
--- a/src/custom-video-texture.js
+++ b/src/custom-video-texture.js
@@ -2,16 +2,15 @@
 import * as THREE from 'three';
 
 class CustomVideoTexture extends THREE.Texture {
-  constructor(ctx2d: CanvasRenderingContext2D, dimensions: Dimensions) {
+  constructor(ctx2d: CanvasRenderingContext2D) {
     super(ctx2d.canvas);
     this._ctx2d = ctx2d;
-    this._dimensions = dimensions;
-    this._ctx2d.canvas.width = this._dimensions.width;
-    this._ctx2d.canvas.height = this._dimensions.height;
   }
 
-  render(videoElement: HTMLVideoElement) {
-    this._ctx2d.drawImage(videoElement, 0, 0, this._dimensions.width, this._dimensions.height);
+  render(videoElement: HTMLVideoElement, dimensions: Dimensions) {
+    this._ctx2d.canvas.width = dimensions.width;
+    this._ctx2d.canvas.height = dimensions.height;
+    this._ctx2d.drawImage(videoElement, 0, 0, dimensions.width, dimensions.height);
   }
 }
 

--- a/src/vr.js
+++ b/src/vr.js
@@ -210,7 +210,7 @@ class Vr extends BasePlugin {
     this._camera = new THREE.PerspectiveCamera(cameraOptions.fov, aspect, cameraOptions.near, cameraOptions.far);
     this._camera.target = new THREE.Vector3(0, 0, 0);
 
-    this._texture = this._getVideoTexture(videoElement, dimensions);
+    this._texture = this._getVideoTexture(videoElement);
     this._texture.minFilter = this._texture.magFilter = THREE.LinearFilter;
     this._texture.generateMipmaps = false;
     this._texture.format = THREE.RGBFormat;
@@ -228,12 +228,12 @@ class Vr extends BasePlugin {
     this._updateCanvasSize();
   }
 
-  _getVideoTexture(videoElement: HTMLVideoElement, dimensions: Dimensions): any {
+  _getVideoTexture(videoElement: HTMLVideoElement): any {
     if (this.player.env.browser.name === 'IE') {
       // a workaround for ie11 texture issue
       // see https://github.com/mrdoob/three.js/issues/7560
       const ctx2d = Utils.Dom.createElement('canvas').getContext('2d');
-      return new CustomVideoTexture(ctx2d, dimensions);
+      return new CustomVideoTexture(ctx2d);
     }
     return new THREE.VideoTexture(videoElement);
   }
@@ -243,7 +243,7 @@ class Vr extends BasePlugin {
     if (this._texture && videoElement.readyState >= videoElement.HAVE_CURRENT_DATA) {
       this._texture.needsUpdate = true;
       if (this._texture instanceof CustomVideoTexture) {
-        this._texture.render(videoElement);
+        this._texture.render(videoElement, this._getCanvasDimensions());
       }
     }
     this._rafId = requestAnimationFrame(this._render.bind(this));


### PR DESCRIPTION
### Description of the Changes

The video element dimensions could be unknown when creating the `CustomVideoTexture`,
So calculate the dimensions in the `render` method.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
