### PR TITLE
fix(FEC-8783): change media, 2nd video isn't draggable

### DIFF
--- a/src/vr.js
+++ b/src/vr.js
@@ -109,7 +109,7 @@ class Vr extends BasePlugin {
       if (this.player.isVr()) {
         this.logger.debug('VR entry has detected');
         if (this._isVrSupported(event.payload.selectedSource[0])) {
-          this.eventManager.listen(this.player, this.player.Event.LOAD_START, () => this._addMotionBindings());
+          this.eventManager.listen(this.player, this.player.Event.MEDIA_LOADED, () => this._addMotionBindings());
           this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => this._initComponents());
           this.eventManager.listen(this.player, this.player.Event.ENDED, () => this._cancelAnimationFrame());
           this.eventManager.listen(this.player, this.player.Event.PLAY, () => this._onPlay());


### PR DESCRIPTION
### Description of the Changes

wait for `MEDIA_LOADED` before listening to the motion event

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
