### PR TITLE
fix: Kaltura player event UI.UI_CLICKED doesn't exist for player

### DIFF
--- a/src/vr.js
+++ b/src/vr.js
@@ -471,8 +471,9 @@ class Vr extends BasePlugin {
 
   _requestDeviceMotionPermission(): void {
     if (this.player.env.os.name === 'iOS' && Utils.VERSION.compare(this.player.env.os.version, '13') > 0) {
+      const rootElement = Utils.Dom.getElementBySelector(`#${this.config.rootElement}`);
       //it will work only on https and popup permission will show up
-      this.eventManager.listenOnce(this.player, this.player.Event.UI.UI_CLICKED, () => {
+      this.eventManager.listenOnce(rootElement, 'click', () => {
         if (window.DeviceOrientationEvent && typeof window.DeviceOrientationEvent.requestPermission === 'function') {
           window.DeviceOrientationEvent.requestPermission()
             .then(permissionState => {


### PR DESCRIPTION
### Description of the Changes

Change the root element to handle the click.
UI.UI_CLICKED doesn't exist in Playkit, it's event of Kaltura player.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
