### PR TITLE
fix(FEC-9602): after entering and exiting full screen, replay icon in not responding

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,5 @@
 .playkit-vr-video {
-  display: none;
+  opacity: 0;
 }
 
 .playkit-vr-canvas {


### PR DESCRIPTION
### Description of the Changes

Seems to be a webkit bug - Combination of Safari, video in display:none and HLS.
There is an open bug in webkit bugzilla - https://bugs.webkit.org/show_bug.cgi?id=210058
Until the issue is solved by Apple I changed the display: none to opacity: 0.
solves FEC-9602
make sure FEC-8489 remains closed

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
