### PR TITLE
fix(FEC-10404): media doesn't work properly on Safari browser - no video displayed - Regression bug

### DIFF
--- a/src/vr.js
+++ b/src/vr.js
@@ -6,7 +6,7 @@ import {StereoEffect} from './stereo-effect';
 import {Error} from './errors';
 import './style.css';
 
-const {Error: PKError, FakeEvent, Utils} = core;
+const {Error: PKError, FakeEvent, Utils, CorsType} = core;
 /**
  * The video tag class.
  * @type {string}
@@ -130,7 +130,7 @@ class Vr extends BasePlugin {
       (env.os.name === 'iOS' || env.browser.name === 'Safari' || env.browser.name === 'Android Browser')
     ) {
       this._crossOriginSet = true;
-      this.player.crossOrigin = this.player.CorsType.ANONYMOUS;
+      this.player.crossOrigin = CorsType.ANONYMOUS;
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

Due to FEC-10057 (move the plugin manager to kaltura player) - Plugins hold a reference to KP and not PK.
KP doesn't have CorsType. Changed to be taken from core import (reference to KP / PK is not needed)

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
