### PR TITLE
fix(FEC-10557): drag on 360 videos cause all screen movement on android

### DIFF
--- a/src/vr.js
+++ b/src/vr.js
@@ -444,6 +444,7 @@ class Vr extends BasePlugin {
   }
 
   _onOverlayActionPointerDown(event: any): void {
+    event.preventDefault();
     this._pointerDown = true;
     this._previousX = event.clientX || event.touches[0].clientX;
     this._previousY = event.clientY || event.touches[0].clientY;


### PR DESCRIPTION
### Description of the Changes

added prevent default to mouse down to prevent the screen scrolling

solves FEC-10557

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
