### PR TITLE
fix(FEC-12514): vr plugin + ima mouse scroll is not working

### DIFF
--- a/src/vr.js
+++ b/src/vr.js
@@ -111,7 +111,6 @@ class Vr extends BasePlugin {
         this.logger.debug('VR entry has detected');
         if (this._isVrSupported(event.payload.selectedSource[0])) {
           this._requestDeviceMotionPermission();
-          this.eventManager.listen(this.player, this.player.Event.MEDIA_LOADED, () => this._addMotionBindings());
           this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => this._initComponents());
           this.eventManager.listen(this.player, this.player.Event.ENDED, () => this._cancelAnimationFrame());
           this.eventManager.listen(this.player, this.player.Event.PLAY, () => this._onPlay());
@@ -201,6 +200,7 @@ class Vr extends BasePlugin {
    */
   _initComponents(): void {
     this.logger.debug('Init VR components');
+    this._addMotionBindings();
     const videoElement = this.player.getVideoElement();
     Utils.Dom.addClassName(videoElement, VIDEO_TAG_CLASS);
 


### PR DESCRIPTION
### Description of the Changes

**the issue:**
after pre-ad the mouse scroll is not working.

**the root cause:**
on media load event we listeners the mouse events on the overlayAction element. when has ad,  on media load event there is no overlayAction element yet so the listeners is not activated.

**the solution:**
activate the listeners in the first play event. 

solves: FEC-12514

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
