### PR TITLE
SUP-46065: Player shows VR button based on "360" (or variations) tag

### DIFF
--- a/src/vr.js
+++ b/src/vr.js
@@ -108,7 +108,7 @@ class Vr extends BasePlugin {
     super(name, player, config);
     this._initMembers();
     this._addBindings();
-    this._updatePlayerVrPluginIsOn(this.config.tag);
+    this.updateVrIsOn(this.config.tag);
   }
 
   /**
@@ -285,9 +285,9 @@ class Vr extends BasePlugin {
     }
   }
 
-  _updatePlayerVrPluginIsOn(vrTag: string): void {
+  updateVrIsOn(vrTag: string): void {
     this._tag = vrTag ?? '360';
-    this.player._updatePlayerVrPluginIsOn(vrTag);
+    this.player.setVrTag(vrTag);
   }
 
   _updateCamera(): void {

--- a/src/vr.js
+++ b/src/vr.js
@@ -286,7 +286,7 @@ class Vr extends BasePlugin {
   }
 
   _updatePlayerVrPluginIsOn(vrTag: string): void {
-    this._tag = vrTag ?? 360;
+    this._tag = vrTag ?? '360';
     this.player._updatePlayerVrPluginIsOn(vrTag);
   }
 

--- a/src/vr.js
+++ b/src/vr.js
@@ -61,6 +61,7 @@ class Vr extends BasePlugin {
    * @static
    */
   static defaultConfig: Object = {
+    tag: '360',
     moveMultiplier: 0.15,
     deviceMotionMultiplier: 1,
     startInStereo: false,
@@ -95,6 +96,7 @@ class Vr extends BasePlugin {
   _longitude: number;
   _calculateCanvasSizeInterval: ?IntervalID;
   _crossOriginSet: boolean;
+  _tag: string;
 
   /**
    * @constructor
@@ -106,7 +108,7 @@ class Vr extends BasePlugin {
     super(name, player, config);
     this._initMembers();
     this._addBindings();
-    this._foo();
+    this._updatePlayerVrPluginIsOn(this.config.tag);
   }
 
   /**
@@ -240,6 +242,7 @@ class Vr extends BasePlugin {
     this._texture.minFilter = this._texture.magFilter = THREE.LinearFilter;
     this._texture.generateMipmaps = false;
     this._texture.format = THREE.RGBFormat;
+    this._tag = this.config.tag ?? 360;
 
     const geometry = new THREE.SphereBufferGeometry(256, 32, 32);
     geometry.applyMatrix(new THREE.Matrix4().makeScale(-1, 1, 1));
@@ -283,9 +286,9 @@ class Vr extends BasePlugin {
     }
   }
 
-  _foo(): void {
-    console.log("got here")
-    this.player.setSourcesObject1();
+  _updatePlayerVrPluginIsOn(vrTag: string): void {
+    this._tag = vrTag;
+    this.player._updatePlayerVrPluginIsOn(vrTag);
   }
 
   _updateCamera(): void {
@@ -459,6 +462,7 @@ class Vr extends BasePlugin {
     this._latitude = 0;
     this._longitude = 180;
     this._crossOriginSet = false;
+    this._tag = null;
   }
 
   _cancelAnimationFrame(): void {

--- a/src/vr.js
+++ b/src/vr.js
@@ -461,7 +461,7 @@ class Vr extends BasePlugin {
     this._latitude = 0;
     this._longitude = 180;
     this._crossOriginSet = false;
-    this._tag = null;
+    this._tag = this.config.tag;
   }
 
   _cancelAnimationFrame(): void {

--- a/src/vr.js
+++ b/src/vr.js
@@ -106,6 +106,7 @@ class Vr extends BasePlugin {
     super(name, player, config);
     this._initMembers();
     this._addBindings();
+    this._foo();
   }
 
   /**
@@ -280,6 +281,11 @@ class Vr extends BasePlugin {
     } else if (this._renderer) {
       this._renderer.render(this._scene, this._camera);
     }
+  }
+
+  _foo(): void {
+    console.log("got here")
+    this.player.setSourcesObject1();
   }
 
   _updateCamera(): void {

--- a/src/vr.js
+++ b/src/vr.js
@@ -242,7 +242,6 @@ class Vr extends BasePlugin {
     this._texture.minFilter = this._texture.magFilter = THREE.LinearFilter;
     this._texture.generateMipmaps = false;
     this._texture.format = THREE.RGBFormat;
-    this._tag = this.config.tag ?? 360;
 
     const geometry = new THREE.SphereBufferGeometry(256, 32, 32);
     geometry.applyMatrix(new THREE.Matrix4().makeScale(-1, 1, 1));
@@ -287,7 +286,7 @@ class Vr extends BasePlugin {
   }
 
   _updatePlayerVrPluginIsOn(vrTag: string): void {
-    this._tag = vrTag;
+    this._tag = vrTag ?? 360;
     this.player._updatePlayerVrPluginIsOn(vrTag);
   }
 


### PR DESCRIPTION
issue:
360 tag is being concat and playing 360VR video when no needed.

fix:
support new feature: add to the configuration a tag in the VR Plugin, and compare it to the metadata tags of the entry.
The tag is being transferred from the plugin to the provider via the player, in this PR's:
https://github.com/kaltura/kaltura-player-js/pull/915
https://github.com/kaltura/playkit-js-providers/pull/255/files

solved:
[SUP-46065](https://kaltura.atlassian.net/browse/SUP-46065)

[SUP-46065]: https://kaltura.atlassian.net/browse/SUP-46065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ